### PR TITLE
Fix the test failure described in RT#123964

### DIFF
--- a/lib/File/Copy/Recursive.pm
+++ b/lib/File/Copy/Recursive.pm
@@ -167,6 +167,9 @@ sub fcopy {
         unlink $new if -l $new;
         symlink( $target, $new ) or return;
     }
+    elsif ( -d $_[0] && -f $_[1] ) {
+        return;
+    }
     else {
         copy(@_) or return;
 


### PR DESCRIPTION
As SREZIC explains, "The difference between FreeBSD and Linux: on
FreeBSD it's possible to sysread from a directory handle."

https://rt.cpan.org/Public/Bug/Display.html?id=123964