### PR TITLE
File::Find::Rule used in test suite but not named as a prerequisite

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,6 +18,7 @@ WriteMakefile(
         'Test::Deep'      => 0,
         'Test::File'      => 0,
         'File::Temp'      => 0,
+        'File::Find::Rule'  => 0,
         'Test::Exception' => 0,
         'Test::Warn'      => 0,
         'Path::Tiny'      => 0,


### PR DESCRIPTION
This probably explains CPANtesters FAIL reports for version 0.41, e.g.,
http://www.cpantesters.org/cpan/report/5bb1293c-4423-11e8-a1cf-bb670eaac09d

Add File::Find::Rule in appropriate place in Makefile.PL