### PR TITLE
Add .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/MYMETA.json
+/MYMETA.yml
+/Makefile
+/blib/
+/pm_to_blib

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,12 +1,13 @@
 Changes
-Makefile.PL
-MANIFEST
-README
 lib/File/Copy/Recursive.pm
+Makefile.PL
+MANIFEST			This list of files
+META.yml
+README
+README.md
 t/00.load.t
 t/01.legacy.t
 t/02.legacy-symtogsafe.t
 t/03.github-issue-5.t
 t/04.readonly-dir.t
 t/05.legacy-pathmk_unc.t
-META.yml                                Module meta-data (added by MakeMaker)


### PR DESCRIPTION
Add .gitignore.

This will silence superfluous reporting of files not needed for git during 'git status'.
    
Update MANIFEST appropriately.