### PR TITLE
Amend prereqs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /Makefile
 /blib/
 /pm_to_blib
+/File-Copy-Recursive-*/
+/File-Copy-Recursive-*.tar.gz

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension File::Copy::Recursive.
 
+    - strip down list of prerequisites to moduels that are safe to use high on
+      the CPAN river
+
 0.42 Fri Apr 20 23:42:41 2018
     - rt 125136 - reinstate 5.8 compat by not using // operator in the new unc test (thanks SREZIC)
     - pull request #14 - Add .gitignore. (thanks jkeenan)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,7 +19,7 @@ WriteMakefile(
         'Test::File'       => 0,
         'File::Temp'       => 0,
         'File::Find::Rule' => 0,
-        'Test::Warn'       => 0,
+        'Test::Warnings'   => 0,
         'Path::Tiny'       => 0,
         'Test::Fatal'      => 0,
     },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,9 +19,9 @@ WriteMakefile(
         'Test::File'       => 0,
         'File::Temp'       => 0,
         'File::Find::Rule' => 0,
-        'Test::Exception'  => 0,
         'Test::Warn'       => 0,
         'Path::Tiny'       => 0,
+        'Test::Fatal'      => 0,
     },
     META_ADD => {
         'meta-spec'    => { version => 2 },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,7 @@ WriteMakefile(
         'Cwd'        => 0,
     },
     TEST_REQUIRES => {
-        'Test::More'       => 0,
+        'Test::More'       => '0.88',
         'Test::Deep'       => 0,
         'Test::File'       => 0,
         'File::Temp'       => 0,

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,7 +18,6 @@ WriteMakefile(
         'Test::Deep'       => 0,
         'Test::File'       => 0,
         'File::Temp'       => 0,
-        'File::Find::Rule' => 0,
         'Test::Warnings'   => 0,
         'Path::Tiny'       => 0,
         'Test::Fatal'      => 0,

--- a/t/01.legacy.t
+++ b/t/01.legacy.t
@@ -11,7 +11,7 @@ BEGIN {
 use Test::More;
 use Test::Deep;
 use Test::File;
-use Test::Warn;
+use Test::Warnings 'warnings';
 use Path::Tiny;
 
 use File::Temp;
@@ -262,17 +262,17 @@ note "functionality w/ 'behavior' globals";
         mkdir "$tmpd/derp";
         path("$tmpd/derp/data")->spew("I exist therefor I am.");
 
-        warning_like {
+        my @warnings = warnings {
             my $rv = File::Copy::Recursive::fcopy( "$tmpd/orig/data", "$tmpd/derp/data" );
             ok( $rv, "fcopy() w/ \$RMTrgFil = 1 to file-returned true" );
-        }
-        qr/RMTrgFil failed/, "fcopy() w/ \$RMTrgFil = 1 to file-warned";
+        };
+        cmp_deeply \@warnings, [ re(qr/RMTrgFil failed/) ], "fcopy() w/ \$RMTrgFil = 1 to file-warned";
 
-        warning_like {
+        @warnings = warnings {
             my $rv = File::Copy::Recursive::fcopy( "$tmpd/orig/data", "$tmpd/derp" );
             ok( $rv, "fcopy() w/ \$RMTrgFil = 1 to dir-returned true" );
-        }
-        qr/RMTrgFil failed/, "fcopy() w/ \$RMTrgFil = 1 to dir-warned";
+        };
+        cmp_deeply \@warnings, [ re(qr/RMTrgFil failed/) ], "fcopy() w/ \$RMTrgFil = 1 to dir-warned";
     }
 
     {
@@ -283,17 +283,17 @@ note "functionality w/ 'behavior' globals";
         mkdir "$tmpd/derp";
         path("$tmpd/derp/data")->spew("I exist therefor I am.");
 
-        warnings_are {
+        my @warnings = warnings {
             my $rv = File::Copy::Recursive::fcopy( "$tmpd/orig/data", "$tmpd/derp/data" );
             ok( !$rv, "fcopy() w/ \$RMTrgFil = 2 to file-returned false" );
-        }
-        [], "fcopy() w/ \$RMTrgFil = 2 to file-no warning";
+        };
+        cmp_deeply \@warnings, [], "fcopy() w/ \$RMTrgFil = 2 to file-no warning";
 
-        warnings_are {
+        @warnings = warnings {
             my $rv = File::Copy::Recursive::fcopy( "$tmpd/orig/data", "$tmpd/derp" );
             ok( !$rv, "fcopy() w/ \$RMTrgFil = 2 to dir-returned false" );
-        }
-        [], "fcopy() w/ \$RMTrgFil = 2 to dir-no warning";
+        };
+        cmp_deeply \@warnings, [], "fcopy() w/ \$RMTrgFil = 2 to dir-no warning";
     }
 
     # TODO (this is one reason why globals are not awesome :/)

--- a/t/02.legacy-symtogsafe.t
+++ b/t/02.legacy-symtogsafe.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
-use Test::Exception;
+use Test::Fatal;
 
 use File::Copy::Recursive qw(pathempty pathrm pathrmdir);
 
@@ -103,7 +103,7 @@ sub _test {
             chdir "$func/cwd" || die "could not toggle dir/symlink (back into $func/cwd): $!\n";
         };
 
-        throws_ok { no strict "refs"; $func->("foo/bar/baz") }
+        like exception { no strict "refs"; $func->("foo/bar/baz") },
         qr/directory .* changed: expected dev=.* ino=.*, actual dev=.* ino=.*, aborting/,
           "$func() detected symlink toggle: $label";
 

--- a/t/05.legacy-pathmk_unc.t
+++ b/t/05.legacy-pathmk_unc.t
@@ -3,9 +3,10 @@ use warnings;
 
 use Cwd;
 use File::Copy::Recursive qw(pathmk pathempty);
-use File::Find::Rule;
 use File::Temp ();
+use Path::Tiny;
 use Test::More;
+use Test::Deep;
 
 diag("Testing legacy File::Copy::Recursive::pathmk() $File::Copy::Recursive::VERSION");
 
@@ -49,23 +50,23 @@ if ( $^O eq 'MSWin32' ) {
 
 my $tempdir = File::Temp->newdir();
 
-my @members = File::Find::Rule->in($tempdir);
-is_deeply( \@members, [$tempdir], 'create temp dir' );
+my @members = _all_files_in($tempdir);
+is_deeply( \@members, [], 'created empty temp dir' );
 
 # create regular path
 pathmk("$tempdir/foo/bar/baz");
 
-@members = File::Find::Rule->in($tempdir);
-is_deeply(
+@members = _all_files_in($tempdir);
+cmp_deeply(
     \@members,
-    [ $tempdir, "$tempdir/foo", "$tempdir/foo/bar", "$tempdir/foo/bar/baz" ],
+    bag("$tempdir/foo", "$tempdir/foo/bar", "$tempdir/foo/bar/baz"),
     'pathmk regular path'
 );
 
 pathempty($tempdir);
 
-@members = File::Find::Rule->in($tempdir);
-is_deeply( \@members, [$tempdir], 'temp dir empty again' );
+@members = _all_files_in($tempdir);
+is_deeply( \@members, [], 'temp dir empty again' );
 
 if ( $^O eq 'MSWin32' ) {
     my $uncpath = translate_to_unc($tempdir);
@@ -73,7 +74,7 @@ if ( $^O eq 'MSWin32' ) {
     # create UNC path
     pathmk("$uncpath/foo/bar/baz");
 
-    @members = File::Find::Rule->in($tempdir);
+    @members = _all_files_in($tempdir);
     is_deeply(
         \@members,
         [
@@ -85,5 +86,17 @@ if ( $^O eq 'MSWin32' ) {
 }
 
 done_testing();
+
+sub _all_files_in {
+    my $dir = shift;
+    my $state = path($dir)->visit(
+        sub {
+            my ($path, $state) = @_;
+            push @{ $state->{files} }, $path;
+        },
+        { recurse => 1 },
+    );
+    return map { "$_" } @{ $state->{files} || [] };
+}
 
 # temp dir is deleted automatically when $tempdir goes out of scope

--- a/t/05.legacy-pathmk_unc.t
+++ b/t/05.legacy-pathmk_unc.t
@@ -5,7 +5,6 @@ use Cwd;
 use File::Copy::Recursive qw(pathmk pathempty);
 use File::Find::Rule;
 use File::Temp ();
-use Test::Exception;
 use Test::More;
 
 diag("Testing legacy File::Copy::Recursive::pathmk() $File::Copy::Recursive::VERSION");


### PR DESCRIPTION
FCR is becoming increasingly high on the cpan river, so it needs to be careful about what prerequisites it uses.  I've removed prereqs that are unneeded, and replaced some with others that are already well-battle-tested high on the river.

The use of Path::Tiny is still problematic (e.g. it prevents Path::Tiny from itself ever using FCR), but that will be addressed later.