### PR TITLE
allow for dev = 0 on NetBSD

### DIFF
--- a/lib/File/Copy/Recursive.pm
+++ b/lib/File/Copy/Recursive.pm
@@ -371,7 +371,7 @@ sub pathempty {
     my $pth = shift;
 
     my ( $orig_dev, $orig_ino ) = ( lstat $pth )[ 0, 1 ];
-    return 2 if !-d _ || !$orig_dev || ( $^O ne 'MSWin32' && !$orig_ino );    #stat.inode is 0 on Windows
+    return 2 if !-d _ || !defined($orig_dev) || ( $^O ne 'MSWin32' && !$orig_ino );    #stat.inode is 0 on Windows
 
     my $starting_point = Cwd::cwd();
     my ( $starting_dev, $starting_ino ) = ( lstat $starting_point )[ 0, 1 ];
@@ -421,7 +421,7 @@ sub pathrm {
     my ( $path, $force, $nofail ) = @_;
 
     my ( $orig_dev, $orig_ino ) = ( lstat $path )[ 0, 1 ];
-    return 2 if !-d _ || !$orig_dev || !$orig_ino;
+    return 2 if !-d _ || !defined($orig_dev) || !$orig_ino;
 
     # Manual test (I hate this function :/):
     #    sudo mkdir /foo && perl -MFile::Copy::Recursive=pathrm -le 'print pathrm("/foo",1)' && sudo rm -rf /foo
@@ -471,7 +471,7 @@ sub pathrmdir {
     }
 
     my ( $orig_dev, $orig_ino ) = ( lstat $dir )[ 0, 1 ];
-    return 2 if !$orig_dev || ( $^O ne 'MSWin32' && !$orig_ino );
+    return 2 if !defined($orig_dev) || ( $^O ne 'MSWin32' && !$orig_ino );
 
     pathempty($dir) or return;
     _bail_if_changed( $dir, $orig_dev, $orig_ino );


### PR DESCRIPTION
This patch fixes #20 for me on NetBSD.  Apparently a the device returned from `stat`/`lstat` can be zero (0).

```
pete% perl -MYAML= -E 'say Dump(lstat "/tmp")'
--- 0
--- 1493440
--- 17407
--- 6
--- 0
--- 0
--- 6152128
--- 512
--- 1549909734
--- 1549909819
--- 1549909819
--- 16384
--- 4
```

I'm not 100% certain that this is "correct" for other systems, if you have a preferred way of fixing this I can test it out on my VM which exhibits the problem.