### PR TITLE
Remove warning when copying a dir without write perm on the original.

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -29,4 +29,4 @@ requires:
   Test::File: '0'
   Test::More: '0'
   Test::Warn: '0'
-version: '0.44'
+version: '0.45'

--- a/lib/File/Copy/Recursive.pm
+++ b/lib/File/Copy/Recursive.pm
@@ -277,7 +277,6 @@ sub dircopy {
                 my $rc;
                 if ( !-w $org && $KeepMode ) {
                     local $KeepMode = 0;
-                    carp "Copying readonly directory ($org); mode of its contents may not be preserved.";
                     $rc = $recurs->( $org, $new, $buf ) if defined $buf;
                     $rc = $recurs->( $org, $new ) if !defined $buf;
                     chmod scalar( ( stat($org) )[2] ), $new;


### PR DESCRIPTION
When dircopy() attempst to copy any directory that it doesn't have
write permissions for it has to follow a few extra steps after firing
off a warning.  The warning sometimes causes confusion and the problem
it describes ends up not being a problem, so the warning has been
removed.