### PR TITLE
Added test support for symlinks in MSYS2.

### DIFF
--- a/t/01.legacy.t
+++ b/t/01.legacy.t
@@ -181,7 +181,8 @@ note "functionality w/ default globals";
         no warnings "redefine";
         local *File::Copy::Recursive::rcopy = sub { push @rcopy_srcs, $_[0] };
         rcopy_glob( "$tmpd/orig/*l*", "$tmpd/rcopy_glob" );
-        is( @rcopy_srcs, $File::Copy::Recursive::CopyLink ? 4 : 1, "rcopy_glob() calls rcopy for each file in the glob" );
+        my $expect = $^O eq 'msys' ? 3 : 4;
+        is( @rcopy_srcs, $File::Copy::Recursive::CopyLink ? $expect : 1, "rcopy_glob() calls rcopy for each file in the glob" );
     }
 
     # rmove_glob()
@@ -190,7 +191,8 @@ note "functionality w/ default globals";
         no warnings "redefine";
         local *File::Copy::Recursive::rmove = sub { push @rmove_srcs, $_[0] };
         rmove_glob( "$tmpd/orig/*l*", "$tmpd/rmove_glob" );
-        is( @rmove_srcs, $File::Copy::Recursive::CopyLink ? 4 : 1, "rmove_glob() calls rmove for each file in the glob" );
+        my $expect = $^O eq 'msys' ? 3 : 4;
+        is( @rmove_srcs, $File::Copy::Recursive::CopyLink ? $expect : 1, "rmove_glob() calls rmove for each file in the glob" );
     }
 
     # pathempty()


### PR DESCRIPTION
Fixes #31. For newer versions of Windows 10 in developer mode symlinks can be enabled in MSYS2 by setting the environment variable MSYS to `winsymlinks:nativestrict`, see [this](https://www.joshkel.com/2018/01/18/symlinks-in-windows/) blog post. Still, it does not support creating broken symlinks as is done `_get_fresh_tmp_dir()` in `t/01.legacy.t`, which is the reason for the failed tests in #31. 